### PR TITLE
AWS - SNS - publish add parameter to publish to FIFO topics

### DIFF
--- a/packages/aws/src/services/sns.ts
+++ b/packages/aws/src/services/sns.ts
@@ -1,8 +1,9 @@
 const awssns = new (require('aws-sdk/clients/sns'));
 
 export const sns = {
-    publish: async ({message, attributes, topic}) => awssns.publish({
+    publish: async ({message, attributes, topic, group }) => awssns.publish({
         Message: JSON.stringify(await message),
+        ...(group ? {MessageGroupId:group} : {}),
         MessageAttributes: Object.entries(attributes).reduce((acc, [k, v]) => {
             acc[k] = {DataType: 'String', StringValue: v};
             return acc;


### PR DESCRIPTION
In case if you are publishing to a fifo SNS topic the parameter messageGroupId is required.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html